### PR TITLE
MEM-433 Change Links on the Authorizations Tab for Mount Polley Mine

### DIFF
--- a/modules/core/client/scss/global/layout.scss
+++ b/modules/core/client/scss/global/layout.scss
@@ -68,7 +68,7 @@ main {
         color: #FFF;
 
         a {
-            color: #FFf;
+            color: $gold;
         }
     }
 }

--- a/modules/projects/client/views/partials/authorizations.html
+++ b/modules/projects/client/views/partials/authorizations.html
@@ -6,10 +6,15 @@
   <tmpl-project-authorizations project="project" agency="ENV"></tmpl-project-authorizations>
   <tmpl-project-authorizations project="project" agency="MEM"></tmpl-project-authorizations>
 
-  <div class="main-footer">
+  <div class="main-footer" ng-if="project.name != 'Mount Polley'">
     <h3>Can't find what you are looking for?</h3>
     <p>Mines Act permits issued for {{project.name}} prior to 2013 can be accessed at <a href="https://mines.empr.gov.bc.ca" target="_blank">mines.empr.gov.bc.ca</a>. These records will be moved to the new BC Mine Information website in the coming months.</p>
     <a class="btn inverted slide-r-btn" href="https://mines.empr.gov.bc.ca" target="_blank"><span>Visit mines.empr.gov.bc.ca</span><i class="material-icons">open_in_new</i></a>
+  </div>
+
+  <div class="main-footer" ng-if="project.name === 'Mount Polley'">
+    <h3>Can't find what you are looking for?</h3>
+    <p class="mb-0">Mines Act permits issued for Mount Polley prior to 2013 can be accessed <a href="https://mines.empr.gov.bc.ca/p/mount-polley/docs?folder=5" target="_blank">here</a>.</p>
   </div>
 
 </div><!-- / Authorizations -->


### PR DESCRIPTION
- Added a unique footer section on the Authorizations Tab to show ONLY for Mount Polley Mine.
- Fixed an issue where hyperlinks in the body footer section of the authorizations tab did not have a strong visual cue