### PR TITLE
Removing the hard-coded inspection dates from the inspections view

### DIFF
--- a/modules/inspections/client/views/project-inspections.html
+++ b/modules/inspections/client/views/project-inspections.html
@@ -1,6 +1,6 @@
 
 <section class="ce-section">
-    <h3>Inspections <span>January 1 - December 31, 2016</span></h3>
+    <h3>Inspections</h3>
     <!--
     <div class="ce-list-header">Viewing {{complianceList.data.length}} Records</div>
     -->


### PR DESCRIPTION
Needed to remove the hard-coded date range from the inspections tab heading.